### PR TITLE
Add python-dateutil to PYTHON_IMPORTS_REPLACEMENT

### DIFF
--- a/backend/parsers/windmill-parser-py-imports/src/lib.rs
+++ b/backend/parsers/windmill-parser-py-imports/src/lib.rs
@@ -32,6 +32,7 @@ static PYTHON_IMPORTS_REPLACEMENT: phf::Map<&'static str, &'static str> = phf_ma
     "smb" => "pysmb",
     "PIL" => "Pillow",
     "googleapiclient" => "google-api-python-client",
+    "dateutil" => "python-dateutil",
 };
 
 fn replace_import(x: String) -> String {


### PR DESCRIPTION
https://pypi.org/project/python-dateutil/
`dateutil can be installed from PyPI using pip (note that the package name is different from the importable name):`